### PR TITLE
Update react tether 0.3.3 -> 0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "webpack-hot-middleware": "^2.6.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0"
+    "react": "^0.14.0 || ^15.x"
   },
   "dependencies": {
     "classnames": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "classnames": "^2.2.1",
     "moment": "^2.13.0",
     "react-onclickoutside": "^4.8.0",
-    "react-tether": "^0.3.3"
+    "react-tether": "^0.5.2"
   },
   "scripts": {
     "build": "NODE_ENV=production grunt build",


### PR DESCRIPTION
react tether 0.3.3 haves a direct dependency on react 0.14. updating this to 0.5.2 changes it to a peerDependecy
