### PR TITLE
Ensure only known input props are transferred

### DIFF
--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -95,10 +95,23 @@ var DateInput = React.createClass({
   },
 
   render () {
+    const {
+      date,
+      dateFormat,
+      excludeDates,
+      filterDate,
+      includeDates,
+      locale,
+      maxDate,
+      minDate,
+      onChangeDate,
+      ...inputProps
+    } = this.props
+
     return <input
         ref='input'
         type='text'
-        {...this.props}
+        {...inputProps}
         value={this.state.maybeDate}
         onBlur={this.handleBlur}
         onKeyDown={this.handleKeyDown}


### PR DESCRIPTION
This gets rid of the warning:

![react-datepicker_unknown_props_warning](https://cloud.githubusercontent.com/assets/319231/19173128/bf19d3e6-8bf3-11e6-914e-2e241370529d.png)
