### PR TITLE
Passe empty string to <input> when date is null

### DIFF
--- a/src/date_input.jsx
+++ b/src/date_input.jsx
@@ -108,11 +108,13 @@ var DateInput = React.createClass({
       ...inputProps
     } = this.props
 
+    const value = this.state.maybeDate ? this.state.maybeDate : ''
+
     return <input
         ref='input'
         type='text'
         {...inputProps}
-        value={this.state.maybeDate}
+        value
         onBlur={this.handleBlur}
         onKeyDown={this.handleKeyDown}
         onChange={this.handleChange} />


### PR DESCRIPTION
This will avoid an error when trying to pass null to <input> value:

```
Warning: `value` prop on `input` should not be null. Consider using the empty string to clear the component or `undefined` for uncontrolled components.
```